### PR TITLE
Fix max in memory size.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,6 @@ info.app:
 spring:
   application:
     name: hmpps-electronic-monitoring-data-insights-api
-  codec:
-    max-in-memory-size: 10MB
-
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:
@@ -23,6 +20,9 @@ spring:
         provider:
           hmpps-auth:
             token-uri: ${hmpps-auth.url}/oauth/token
+  http:
+    codecs:
+      max-in-memory-size: 10MB
 
 server:
   port: 8080


### PR DESCRIPTION
This has been deprecated and in the next version of spring has been removed and so will cause problems when we move to SB4 on any request that returns more than the default size of ~ 260kb. 