### PR TITLE
added mpop discovery endpoint

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,8 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui-dev.hmpps.service.justice.gov.uk"
+    SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api-dev.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"
     ROW_LIMIT: 1000
     MDSS_DB: "staged_mdss_dev_dbt"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,8 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui-preprod.hmpps.service.justice.gov.uk"
+    SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api-preprod.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"
     ROW_LIMIT: 1000
     MDSS_DB: "staged_mdss_dev_dbt"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,8 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui.hmpps.service.justice.gov.uk"
+    SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"
     ROW_LIMIT: 1000
     MDSS_DB: "staged_mdss_dev_dbt"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/ElectronicMonitoringDataInsightsApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/ElectronicMonitoringDataInsightsApi.kt
@@ -4,10 +4,12 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.device.model.DeviceEvents
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.location.model.Locations
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.watermark.Watermarks
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 class ElectronicMonitoringDataInsightsApi
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/HmppsAuthProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/HmppsAuthProperties.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config
+
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for HMPPS Auth service.
+ *
+ * Properties are bound from the `hmpps-auth.*` prefix in application configuration.
+ */
+@ConfigurationProperties(prefix = "hmpps-auth")
+data class HmppsAuthProperties(
+  /**
+   * Base URL for HMPPS Auth service.
+   */
+  @field:NotBlank(message = "Base URL must not be blank")
+  val url: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/ServiceProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/ServiceProperties.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config
+
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for the service itself.
+ *
+ * Properties are bound from the `service.*` prefix in application configuration.
+ */
+@ConfigurationProperties(prefix = "service")
+data class ServiceProperties(
+  /**
+   * Base URL for this service, used for generating detail URLs in domain events.
+   */
+  @field:NotBlank(message = "Base URL must not be blank")
+  val baseUrl: String,
+
+  /**
+   * Base URL for the UI service, used for generating URLS.
+   */
+  @field:NotBlank(message = "UI Base URL must not be blank")
+  val uiBaseUrl: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
@@ -15,15 +15,20 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.HAS_VIEW_ROLE
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.ServiceProperties
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.PeopleQueryCriteria
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.Person
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.service.PersonService
+import java.net.URI
 import kotlin.time.ExperimentalTime
 
 @RestController
 @RequestMapping("/people", produces = ["application/json"])
 @Tag(name = "People", description = "Endpoints for person details")
-class PersonController(private val personService: PersonService) {
+class PersonController(
+  private val personService: PersonService,
+  private val serviceProperties: ServiceProperties,
+) {
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -60,6 +65,28 @@ class PersonController(private val personService: PersonService) {
 
     return if (person != null) {
       ResponseEntity.ok(person)
+    } else {
+      ResponseEntity.notFound().build()
+    }
+  }
+
+  @PreAuthorize(HAS_VIEW_ROLE)
+  @Operation(tags = ["People"], summary = "Endpoint to establish whether a person exists in EMDI")
+  @RequestMapping(method = [RequestMethod.GET], path = ["/exists/{crn}" ], produces = [MediaType.APPLICATION_JSON_VALUE])
+  fun existsInEMDI(
+    @PathVariable @Parameter(description = "The crn of the person", required = true) crn: String,
+  ): ResponseEntity<ExistsInEMDI> {
+    val exists = personService
+      .searchPeople(PeopleQueryCriteria(deliusId = crn))
+      .persons
+      .isNotEmpty()
+
+    return if (exists) {
+      ResponseEntity.ok(
+        ExistsInEMDI(
+          URI("${serviceProperties.uiBaseUrl}/person/$crn/locations"),
+        ),
+      )
     } else {
       ResponseEntity.notFound().build()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonResponse.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.api
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.Person
+import java.net.URI
 
 data class PersonResponse(
   val persons: List<Person>,
   val nextToken: String?,
 )
+
+data class ExistsInEMDI(val uri: URI)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/service/PersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/service/PersonService.kt
@@ -5,13 +5,11 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.m
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.PeopleQueryCriteria
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.Person
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.repository.PersonRepository
-import kotlin.time.ExperimentalTime
 
 @Service
 class PersonService(private val personRepository: PersonRepository) {
 
-  fun searchPeople(personsQueryCriteria: PeopleQueryCriteria, nextToken: String?): PagedPeople = this.personRepository.searchPeople(personsQueryCriteria, nextToken)
+  fun searchPeople(personsQueryCriteria: PeopleQueryCriteria, nextToken: String? = null): PagedPeople = this.personRepository.searchPeople(personsQueryCriteria, nextToken)
 
-  @OptIn(ExperimentalTime::class)
   fun getPersonById(personId: String): Person? = personRepository.findByPersonById(personId)
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,3 +18,7 @@ aws:
     pollIntervalMs: 500
     timeoutMs: 60000
     role: ${ATHENA_GENERAL_IAM_ROLE:}
+
+service:
+  base-url: http://localhost:8081
+  ui-base-url: http://localhost:8081

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,3 +74,7 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: true
+
+service:
+  base-url: ${SERVICE_BASE_URL}
+  ui-base-url: ${UI_SERVICE_BASE_URL}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/person/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/person/PersonSearchTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.api.ExistsInEMDI
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.api.PersonResponse
 import java.time.LocalDate
 
@@ -73,5 +74,26 @@ class PersonSearchTest : IntegrationTestBase() {
       .headers(setAuthorisation())
       .exchange()
       .expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `Exists endpoint returns the correct URL`() {
+    stubQueryExecution(
+      "123",
+      1,
+      "SUCCEEDED",
+      "athenaResponses/people.search.success.json",
+    )
+
+    val response = webTestClient.get()
+      .uri("/people/exists/X123456")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<ExistsInEMDI>()
+      .returnResult()
+      .responseBody!!
+
+    assertThat(response.uri.toString()).isEqualTo("http://localhost:8081/person/X123456/locations")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
@@ -9,6 +9,10 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.ServiceProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.PagedPeople
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.PeopleQueryCriteria
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.Person
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.service.PersonService
 
@@ -17,6 +21,9 @@ class PersonControllerTest {
 
   @Mock
   private lateinit var personService: PersonService
+
+  @Mock
+  private lateinit var serviceProperties: ServiceProperties
 
   @InjectMocks
   private lateinit var controller: PersonController
@@ -48,5 +55,43 @@ class PersonControllerTest {
     assertThat(result.statusCode.value()).isEqualTo(404)
 
     verify(personService, times(1)).getPersonById(personId)
+  }
+
+  @Test
+  fun `exists endpoint should return 200 and person when they exist`() {
+    val crn = "X123456"
+    val mockPeople = PagedPeople(listOf(Person(personId = "123456")), null)
+
+    whenever(
+      personService.searchPeople(
+        personsQueryCriteria = PeopleQueryCriteria(deliusId = crn),
+      ),
+    ).thenReturn(mockPeople)
+
+    val result = controller.existsInEMDI(crn)
+
+    assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    assertThat(result.body).isNotNull()
+    assertThat(result.body!!.uri.toString()).contains(crn)
+  }
+
+  @Test
+  fun `exists endpoint should return 404 when person does not exist`() {
+    // Arrange
+    val crn = "X123456"
+    val mockPeople = PagedPeople(emptyList(), null)
+
+    whenever(
+      personService.searchPeople(
+        personsQueryCriteria = PeopleQueryCriteria(deliusId = crn),
+      ),
+    ).thenReturn(mockPeople)
+
+    // Act
+    val result = controller.existsInEMDI(crn)
+
+    // Assert
+    assertThat(result.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+    assertThat(result.body).isNull()
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,3 +20,7 @@ aws:
     workgroup: AthenaAdmin
     pollIntervalMs: 500
     timeoutMs: 60000
+
+service:
+  base-url: http://localhost:8081
+  ui-base-url: http://localhost:8081


### PR DESCRIPTION
New endpoint to be used by MPOP to establish whether EM data exists for a person on probation. 

The endpoint takes in a CRN and if the person exists within the EM data it will return the URL of the person within EM. If they do not exist it will return a 404. 

The return response is an object rather than a simple string so that in future we may return additional data about the person eg the kind of tag data EM holds. 