### PR TITLE
FIX: set AWS env vars for local integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,4 +69,11 @@ tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25
   }
+
+  test {
+    environment("AWS_ACCESS_KEY_ID", "test")
+    environment("AWS_SECRET_ACCESS_KEY", "test")
+    environment("AWS_SESSION_TOKEN", "test")
+    environment("AWS_REGION", "eu-west-2")
+  }
 }


### PR DESCRIPTION
- - Set dummy AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION on test task