### PR TITLE
Implement global exception handler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/common/exception/ErrorAttributesConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/common/exception/ErrorAttributesConfiguration.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.exception
+
+import org.springframework.boot.web.error.ErrorAttributeOptions
+import org.springframework.boot.web.error.ErrorAttributeOptions.Include
+import org.springframework.boot.webmvc.error.DefaultErrorAttributes
+import org.springframework.context.MessageSource
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.validation.FieldError
+import org.springframework.web.context.request.WebRequest
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.Date
+import java.util.Locale
+
+@Configuration
+class ErrorAttributesConfiguration {
+
+  @Bean
+  fun apiRequestErrorAttributes(messageSource: MessageSource) = ApiRequestErrorAttributes(messageSource)
+}
+
+class ApiRequestErrorAttributes(
+  private val messageSource: MessageSource,
+) : DefaultErrorAttributes() {
+
+  companion object {
+    private const val TIMESTAMP = "timestamp"
+    private const val STATUS = "status"
+    private const val ERROR = "error"
+    private const val MESSAGE = "message"
+    private const val ERRORS = "errors"
+
+    private val errorAttributeOptions = ErrorAttributeOptions.defaults()
+      .including(Include.MESSAGE, Include.BINDING_ERRORS)
+  }
+
+  fun getErrorResponse(request: WebRequest): ErrorResponse = getErrorAttributes(request, errorAttributeOptions).let {
+    ErrorResponse(
+      status = it.getStatus(),
+      errorCode = it.getError(),
+      userMessage = it.getMessage(),
+      developerMessage = it.getErrors().toString(),
+    )
+  }
+
+  private fun Map<String, Any?>.getTimeStamp(): OffsetDateTime = (this[TIMESTAMP] as Date).toInstant().atOffset(ZoneOffset.UTC)
+
+  private fun Map<String, Any?>.getStatus(): Int = this[STATUS] as Int
+
+  private fun Map<String, Any?>.getError(): String = this[ERROR].toString()
+
+  private fun Map<String, Any?>.getMessage(): String = this[MESSAGE].toString()
+
+  private fun Map<String, Any?>.getErrors(): List<String>? = (this[ERRORS] as List<*>?)
+    ?.map { it as FieldError }
+    ?.map {
+      with(it) {
+        val message = messageSource.getMessage(this, Locale.getDefault())
+        "Error on field '$field': rejected value [$rejectedValue], $message"
+      }
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/common/exception/ErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/common/exception/ErrorResponse.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.exception
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * A generic response body object describing errors in a web request, and can be used to communicate several different types of error condition such as (but not limited to) `400 BAD REQUEST`, `409 CONFLICT` etc. 
+ * @param status The HTTP status code.
+ * @param errorCode An optional application specific error code.
+ * @param userMessage An optional human readable description of the error.
+ * @param developerMessage An optional error message that may have more technical information for developers.
+ * @param moreInfo Optional more detailed information about the error.
+ */
+data class ErrorResponse(
+
+  @field:Schema(example = "400", required = true, description = "The HTTP status code.")
+  @get:JsonProperty("status", required = true) val status: Int,
+
+  @field:Schema(example = "null", description = "An optional application specific error code.")
+  @get:JsonProperty("errorCode") val errorCode: String? = null,
+
+  @field:Schema(example = "No locations found for CRN X123456", description = "An optional human readable description of the error.")
+  @get:JsonProperty("userMessage") val userMessage: String? = null,
+
+  @field:Schema(example = "null", description = "An optional error message that may have more technical information for developers.")
+  @get:JsonProperty("developerMessage") val developerMessage: String? = null,
+
+  @field:Schema(example = "null", description = "Optional more detailed information about the error.")
+  @get:JsonProperty("moreInfo") val moreInfo: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/common/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,176 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.exception
+
+import jakarta.servlet.RequestDispatcher
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.ElementKind
+import mu.KotlinLogging
+import org.hibernate.validator.internal.engine.path.PathImpl
+import org.springframework.beans.TypeMismatchException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Global Exception Handler. Handles specific exceptions thrown by the application by returning a suitable [ErrorResponse]
+ * response entity.
+ *
+ * Our standard pattern here is to return an [ErrorResponse]. Please think carefully about writing a response handler
+ * method that does not follow this pattern. Please try not to use [handleExceptionInternal] as this returns a response
+ * body of a simple string rather than a structured response body.
+ *
+ * Our preferred approach is to use the method [populateErrorResponseAndHandleExceptionInternal] which builds and returns
+ * the [ErrorResponse] complete with correctly populated status code field. This method also populates the message field
+ * of [ErrorResponse] from the exception. In the case that the exception message is not suitable for exposing through
+ * the REST API, this can be overridden by manually setting the message on the request attribute. eg:
+ *
+ * ```
+ *     request.setAttribute(ERROR_MESSAGE, "A simpler error message that does not expose internal detail", SCOPE_REQUEST)
+ * ```
+ *
+ */
+@RestControllerAdvice
+class GlobalExceptionHandler(private val errorAttributes: ApiRequestErrorAttributes) : ResponseEntityExceptionHandler() {
+
+  /**
+   * Exception handler to return a 403 Forbidden ErrorResponse for an AccessDeniedException.
+   */
+  @ExceptionHandler(
+    value = [
+      AccessDeniedException::class,
+    ],
+  )
+  protected fun handleAccessDeniedExceptionReturnForbiddenErrorResponse(
+    e: RuntimeException,
+    request: WebRequest,
+  ): ResponseEntity<Any> {
+    log.info("Access denied exception: {}", e.message)
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.FORBIDDEN.value(),
+          userMessage = e.message,
+          developerMessage = "Access denied on ${request.getDescription(false)}",
+        ),
+      )
+  }
+
+  /**
+   * Exception handler to return a 400 Bad Request ErrorResponse, specifically for a ConstraintViolationException.
+   *
+   * This is because the message property of ConstraintViolationException does not contain sufficient/formatted details
+   * as to the nature of the constraint violations. This handler constructs the error message from each violation in the
+   * exception, before using it to create the ErrorResponse which is rendered through the REST API.
+   */
+  @ExceptionHandler(ConstraintViolationException::class)
+  fun handleConstraintViolationException(
+    e: ConstraintViolationException,
+    request: WebRequest,
+  ): ResponseEntity<Any>? {
+    val violations: Set<ConstraintViolation<*>> = e.constraintViolations
+    val errorMessage = if (violations.isNotEmpty()) {
+      violations.joinToString {
+        if (it.relatesToNamedParameter()) {
+          "${it.propertyPath} ${it.message}"
+        } else {
+          it.message
+        }
+      }
+    } else {
+      "Validation error"
+    }
+    request.setAttribute(RequestDispatcher.ERROR_MESSAGE, errorMessage, RequestAttributes.SCOPE_REQUEST)
+    return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
+  }
+
+  /**
+   * Overrides the MethodArgumentNotValidException exception handler to return a 400 Bad Request ErrorResponse
+   */
+  override fun handleMethodArgumentNotValid(
+    e: MethodArgumentNotValidException,
+    headers: HttpHeaders,
+    status: HttpStatusCode,
+    request: WebRequest,
+  ): ResponseEntity<Any>? = populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
+
+  /**
+   * Overrides the HttpMessageNotReadableException exception handler to return a 400 Bad Request ErrorResponse
+   */
+  override fun handleHttpMessageNotReadable(
+    e: HttpMessageNotReadableException,
+    headers: HttpHeaders,
+    status: HttpStatusCode,
+    request: WebRequest,
+  ): ResponseEntity<Any>? = populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
+
+  override fun handleTypeMismatch(
+    e: TypeMismatchException,
+    headers: HttpHeaders,
+    status: HttpStatusCode,
+    request: WebRequest,
+  ): ResponseEntity<Any>? = populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
+
+  @ExceptionHandler(Exception::class)
+  fun unexpectedExceptionHandler(e: Exception, request: WebRequest): ResponseEntity<Any>? {
+    log.error("Unexpected exception", e)
+    request.setAttribute(RequestDispatcher.ERROR_MESSAGE, "Service unavailable", RequestAttributes.SCOPE_REQUEST)
+    return populateErrorResponseAndHandleExceptionInternal(e, HttpStatus.INTERNAL_SERVER_ERROR, request)
+  }
+
+  /**
+   * Exception handler to return a 404 Not Found ErrorResponse
+   */
+  @ExceptionHandler(
+    value = [
+      IllegalArgumentException::class,
+    ],
+  )
+  fun handleIllegalArgumentExceptionErrorResponse(
+    e: RuntimeException,
+    request: WebRequest,
+  ): ResponseEntity<ErrorResponse> {
+    log.info("IllegalArgumentException: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST.value(),
+          userMessage = e.message,
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  private fun populateErrorResponseAndHandleExceptionInternal(
+    exception: Exception,
+    status: HttpStatus,
+    request: WebRequest,
+  ): ResponseEntity<Any>? {
+    request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, status.value(), RequestAttributes.SCOPE_REQUEST)
+    val body = errorAttributes.getErrorResponse(request)
+    return handleExceptionInternal(exception, body, HttpHeaders(), status, request)
+  }
+
+  /**
+   * Returns true is this [ConstraintViolation] relates to a named parameter such as a constraint annotation on a
+   * property in the request body, or a constraint annotation on the method argument.
+   * Knowing whether the constraint relates to a named parameter means we can use the name in the error response.
+   */
+  private fun ConstraintViolation<*>.relatesToNamedParameter(): Boolean = propertyPath is PathImpl &&
+    when ((propertyPath as PathImpl).leafNode.kind) {
+      ElementKind.PROPERTY, ElementKind.PARAMETER -> true
+      else -> false
+    }
+}


### PR DESCRIPTION
Copied from a previous project - a mechanism to elegantly handle exceptions so that they can be wrapped as 400 409s etc rather than the unpleasant 500 errors. 