### PR TITLE
Updated endpoint to use probation search to get extra IDs

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,5 +10,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IOOPENTELEMETRY-17280222:
+    - '*':
+        reason: Suppression for baggage limits issue as we use header size limits
+        expires: 2026-07-11T00:00:00.000Z
+        created: 2026-06-11T07:38:00.250Z
 patch: {}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     PROBATION_SEARCH_API_URL: "https://probation-offender-search-dev.hmpps.service.justice.gov.uk"
+    PROBATION_SEARCH_ENABLED: "true"
     UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui-dev.hmpps.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api-dev.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    PROBATION_SEARCH_API_URL: "https://probation-offender-search-dev.hmpps.service.justice.gov.uk"
     UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui-dev.hmpps.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api-dev.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    PROBATION_SEARCH_API_URL: "https://probation-offender-search-preprod.hmpps.service.justice.gov.uk"
     UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui-preprod.hmpps.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api-preprod.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,6 +13,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     PROBATION_SEARCH_API_URL: "https://probation-offender-search-preprod.hmpps.service.justice.gov.uk"
+    PROBATION_SEARCH_ENABLED: "false"
     UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui-preprod.hmpps.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api-preprod.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     PROBATION_SEARCH_API_URL: "https://probation-offender-search.hmpps.service.justice.gov.uk"
+    PROBATION_SEARCH_ENABLED: "false"
     UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui.hmpps.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,6 +9,7 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    PROBATION_SEARCH_API_URL: "https://probation-offender-search.hmpps.service.justice.gov.uk"
     UI_SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-ui.hmpps.service.justice.gov.uk"
     SERVICE_BASE_URL: "https://electronic-monitoring-data-insights-api.hmpps.service.justice.gov.uk"
     MFA_REQUIRED: "false"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchApiClient.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToFlux
+import reactor.core.publisher.Mono
+
+@Component
+class ProbationSearchApiClient(
+  @param:Qualifier("probationSearchApiWebClient")
+  private val probationSearchApiWebClient: WebClient,
+) {
+
+  /**
+   * Searches Delius for offenders matching a CRN and returns their linked identifiers.
+   */
+  fun searchByCrn(crn: String): List<OtherIds> = probationSearchApiWebClient
+    .post()
+    .uri("/search")
+    .contentType(MediaType.APPLICATION_JSON)
+    .bodyValue(ProbationSearchRequest(crn = crn))
+    .retrieve()
+    .bodyToFlux<ProbationSearchOffender>()
+    .collectList()
+    .map { offenders -> offenders.mapNotNull { it.otherIds } }
+    .onErrorResume {
+      Mono.error(ProbationSearchApiException("Error searching Probation Search API by CRN $crn", it))
+    }
+    .block()!!
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchApiException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchApiException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch
+
+class ProbationSearchApiException(message: String, throwable: Throwable) : RuntimeException(message, throwable)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchModels.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchModels.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+data class ProbationSearchRequest(
+  val crn: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ProbationSearchOffender(
+  val otherIds: OtherIds? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class OtherIds(
+  val crn: String? = null,
+  val pncNumber: String? = null,
+  val croNumber: String? = null,
+  val niNumber: String? = null,
+  val nomsNumber: String? = null,
+  val immigrationNumber: String? = null,
+  val mostRecentPrisonerNumber: String? = null,
+  val previousCrn: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/WebClientConfiguration.kt
@@ -3,17 +3,31 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.properties.ApiProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.properties.ApisProperties
+import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
-import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
   @Value("\${hmpps-auth.url}") val hmppsAuthBaseUri: String,
-  @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
-  @Value("\${api.timeout:20s}") val timeout: Duration,
+  private val apiProperties: ApiProperties,
+  private val apisProperties: ApisProperties,
 ) {
   // HMPPS Auth health ping is required if your service calls HMPPS Auth to get a token to call other services
   @Bean
-  fun hmppsAuthHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(hmppsAuthBaseUri, healthTimeout)
+  fun hmppsAuthHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(hmppsAuthBaseUri, apiProperties.healthTimeout)
+
+  @Bean(name = ["probationSearchApiWebClient"])
+  fun probationSearchApiWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    builder: WebClient.Builder,
+  ): WebClient = builder.authorisedWebClient(
+    authorizedClientManager,
+    registrationId = "probation-search-api",
+    url = apisProperties.probationSearchApi.url,
+    timeout = apiProperties.timeout,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/properties/ApiProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/properties/ApiProperties.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.properties
+
+import jakarta.validation.constraints.NotNull
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * Configuration properties for API timeout settings.
+ *
+ * Properties are bound from the `api.*` prefix in application configuration.
+ */
+@ConfigurationProperties(prefix = "api")
+data class ApiProperties(
+  /**
+   * Timeout duration for health check endpoints.
+   * Default: 2 seconds
+   */
+  @field:NotNull
+  val healthTimeout: Duration = Duration.ofSeconds(2),
+
+  /**
+   * General timeout duration for API calls.
+   * Default: 20 seconds
+   */
+  @field:NotNull
+  val timeout: Duration = Duration.ofSeconds(20),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/properties/ApisProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/config/properties/ApisProperties.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.properties
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for external API endpoints.
+ *
+ * Properties are bound from the `apis.*` prefix in application configuration.
+ */
+@ConfigurationProperties(prefix = "apis")
+data class ApisProperties(
+  /**
+   * Probation Search API configuration.
+   */
+  @field:Valid
+  val probationSearchApi: ApiEndpoint,
+
+) {
+  /**
+   * Configuration for an individual API endpoint.
+   */
+  data class ApiEndpoint(
+    /**
+     * Base URL for the API endpoint.
+     */
+    @field:NotBlank(message = "API URL must not be blank")
+    val url: String,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
@@ -151,7 +151,13 @@ class PersonController(
   }
 
   private fun findPerson(crn: String): PeopleQueryCriteria {
-    val otherIds = probationSearchApiClient.searchByCrn(crn).firstOrNull()
+    val probationSearchOtherIds = probationSearchApiClient.searchByCrn(crn)
+    log.info(
+      "Probation Search returned ids for CRN {}: {}",
+      crn,
+      probationSearchOtherIds.joinToString { "crn=${it.crn}, pncNumber=${it.pncNumber}, nomsNumber=${it.nomsNumber}" },
+    )
+    val otherIds = probationSearchOtherIds.firstOrNull()
 
     return PeopleQueryCriteria(
       deliusId = crn,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
@@ -74,7 +74,7 @@ class PersonController(
       )
     }
 
-    val pagedPeople = personService.searchPeople(peopleQueryCriteria, nextToken)
+    val pagedPeople = personService.searchPeople(enrichPeopleQueryCriteria(peopleQueryCriteria))
 
     return ResponseEntity.ok(
       PersonResponse(
@@ -155,6 +155,23 @@ class PersonController(
     } else {
       ResponseEntity.notFound().build()
     }
+  }
+
+  private fun enrichPeopleQueryCriteria(peopleQueryCriteria: PeopleQueryCriteria): PeopleQueryCriteria {
+    val deliusId = peopleQueryCriteria.deliusId
+      ?.trim()
+      ?.takeIf(String::isNotEmpty)
+
+    if (!peopleQueryCriteria.enrichIds || deliusId == null) {
+      return peopleQueryCriteria
+    }
+
+    val enrichedPeopleQueryCriteria = findPerson(deliusId)
+
+    return peopleQueryCriteria.copy(
+      nomisId = peopleQueryCriteria.nomisId ?: enrichedPeopleQueryCriteria.nomisId,
+      pncId = peopleQueryCriteria.pncId ?: enrichedPeopleQueryCriteria.pncId,
+    )
   }
 
   private fun findPerson(crn: String): PeopleQueryCriteria {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch.ProbationSearchApiClient
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.HAS_VIEW_ROLE
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.service.CurrentUserService
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.ServiceProperties
@@ -35,6 +36,7 @@ class PersonController(
   private val serviceProperties: ServiceProperties,
   private val currentUserService: CurrentUserService,
   private val devPersonProvider: ObjectProvider<DevPersonProvider>,
+  private val probationSearchApiClient: ProbationSearchApiClient,
   @Value("\${dev.stub.enabled:false}")
   private val devStubEnabled: Boolean,
 ) {
@@ -119,11 +121,6 @@ class PersonController(
   fun existsInEMDI(
     @PathVariable @Parameter(description = "The crn of the person", required = true) crn: String,
   ): ResponseEntity<ExistsInEMDI> {
-    val username = currentUserService.username()
-    log.info("Checking user {} has access to this crn {}", username, crn)
-    // TODO use probation integration service here to see if the user can access this CRN
-    log.info("User {} has access to this crn {}", username, crn)
-
     val provider = devPersonProvider.ifAvailable
 
     val exists = if (
@@ -134,8 +131,10 @@ class PersonController(
       log.info("Using hardcoded dev person in existsInEMDI endpoint")
       true
     } else {
+      val peopleQueryCriteria = findPerson(crn)
+
       personService
-        .searchPeople(PeopleQueryCriteria(deliusId = crn))
+        .searchPeople(peopleQueryCriteria)
         .persons
         .isNotEmpty()
     }
@@ -149,5 +148,15 @@ class PersonController(
     } else {
       ResponseEntity.notFound().build()
     }
+  }
+
+  private fun findPerson(crn: String): PeopleQueryCriteria {
+    val otherIds = probationSearchApiClient.searchByCrn(crn).firstOrNull()
+
+    return PeopleQueryCriteria(
+      deliusId = crn,
+      pncId = otherIds?.pncNumber,
+      nomisId = otherIds?.nomsNumber,
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonController.kt
@@ -39,6 +39,8 @@ class PersonController(
   private val probationSearchApiClient: ProbationSearchApiClient,
   @Value("\${dev.stub.enabled:false}")
   private val devStubEnabled: Boolean,
+  @Value("\${probation.search.enabled:false}")
+  private val probationSearchEnabled: Boolean,
 ) {
 
   companion object {
@@ -121,6 +123,11 @@ class PersonController(
   fun existsInEMDI(
     @PathVariable @Parameter(description = "The crn of the person", required = true) crn: String,
   ): ResponseEntity<ExistsInEMDI> {
+    val username = currentUserService.username()
+    log.info("Checking user {} has access to this crn {}", username, crn)
+    // TODO use probation integration service here to see if the user can access this CRN
+    log.info("User {} has access to this crn {}", username, crn)
+
     val provider = devPersonProvider.ifAvailable
 
     val exists = if (
@@ -151,6 +158,10 @@ class PersonController(
   }
 
   private fun findPerson(crn: String): PeopleQueryCriteria {
+    if (!probationSearchEnabled) {
+      return PeopleQueryCriteria(deliusId = crn)
+    }
+
     val probationSearchOtherIds = probationSearchApiClient.searchByCrn(crn)
     log.info(
       "Probation Search returned ids for CRN {}: {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/model/PeopleQueryCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/model/PeopleQueryCriteria.kt
@@ -9,6 +9,7 @@ data class PeopleQueryCriteria(
   val horId: String? = null,
   val ceprId: String? = null,
   val prisonId: String? = null,
+  val enrichIds: Boolean = true,
 ) {
   @AssertTrue(message = "At least one of the following must be provided: nomisId, pncId, deliusId, horId, ceprId, prisonId")
   fun isValid(): Boolean = !(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/model/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/model/Person.kt
@@ -19,4 +19,5 @@ constructor(
   val zip: String? = null,
   val city: String? = null,
   val street: String? = null,
+  val orderId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepository.kt
@@ -42,9 +42,9 @@ class AthenaPersonRepository(
   private fun buildPersonSearchSql(personsQueryCriteria: PeopleQueryCriteria): SqlAndParams {
     val builder = WhereBuilder()
 
-    builder.addEq("c.nomis_id", personsQueryCriteria.nomisId)
-    builder.addEq("c.pnc_id", personsQueryCriteria.pncId)
-    builder.addEq("c.delius_id", personsQueryCriteria.deliusId)
+    builder.addAnyEq(
+      *identifierCriteria(personsQueryCriteria).toTypedArray(),
+    )
     builder.addIn(
       "c.enforceable_condition",
       Constants.ENFORCEABLE_CONDITIONS,
@@ -79,6 +79,39 @@ class AthenaPersonRepository(
     return SqlAndParams(sql, builder.params)
   }
 
+  private fun identifierCriteria(personsQueryCriteria: PeopleQueryCriteria): List<Pair<String, String?>> = listOf(
+    listOf("c.nomis_id" to personsQueryCriteria.nomisId),
+    pncIdVariations(personsQueryCriteria.pncId).map { "c.pnc_id" to it },
+    listOf("c.delius_id" to personsQueryCriteria.deliusId),
+  ).flatten()
+
+  private fun pncIdVariations(pncId: String?): List<String> {
+    val trimmedPncId = pncId
+      ?.trim()
+      ?.takeIf(String::isNotEmpty)
+      ?: return emptyList()
+
+    val match = PNC_ID_WITH_SLASH_REGEX.matchEntire(trimmedPncId)
+      ?: return listOf(trimmedPncId)
+
+    val year = match.groupValues[1]
+    val numberAndSuffix = match.groupValues[2]
+    val alternateYear = if (year.length == 2) {
+      centuryPrefix(year) + year
+    } else {
+      year.takeLast(2)
+    }
+
+    return listOf(
+      "$year/$numberAndSuffix",
+      "$year$numberAndSuffix",
+      "$alternateYear/$numberAndSuffix",
+      "$alternateYear$numberAndSuffix",
+    ).distinct()
+  }
+
+  private fun centuryPrefix(twoDigitYear: String): String = if (twoDigitYear.toInt() >= 50) "19" else "20"
+
   private class WhereBuilder {
     val where = StringBuilder("WHERE 1=1\n")
     val params = mutableListOf<String>()
@@ -90,6 +123,22 @@ class AthenaPersonRepository(
           where.append("  AND $column = CAST(? AS VARCHAR)\n")
           params += it
         }
+    }
+
+    fun addAnyEq(vararg criteria: Pair<String, String?>) {
+      val cleanedCriteria = criteria
+        .mapNotNull { (column, raw) ->
+          raw?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?.let { column to it }
+        }
+
+      if (cleanedCriteria.isEmpty()) return
+
+      val conditions = cleanedCriteria.joinToString(" OR ") { (column) -> "$column = CAST(? AS VARCHAR)" }
+
+      where.append("  AND ($conditions)\n")
+      params += cleanedCriteria.map { (_, value) -> value }
     }
 
     fun addIn(column: String, values: List<String>?) {
@@ -264,6 +313,7 @@ class AthenaPersonRepository(
   }
 
   companion object {
+    private val PNC_ID_WITH_SLASH_REGEX = Regex("""^(\d{2}|\d{4})/([0-9]+[A-Za-z]?)$""")
     private const val COL_PERSON_ID = 0
     private const val COL_CONSUMER_ID = 1
     private const val COL_PERSON_NAME = 2

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepository.kt
@@ -115,6 +115,7 @@ class AthenaPersonRepository(
 
     val year = match.groupValues[1]
     val numberAndSuffix = match.groupValues[2]
+    val trimmedNumberAndSuffix = trimLeadingZeroesFromPncNumber(numberAndSuffix)
     val alternateYear = if (year.length == 2) {
       centuryPrefix(year) + year
     } else {
@@ -126,7 +127,15 @@ class AthenaPersonRepository(
       "$year$numberAndSuffix",
       "$alternateYear/$numberAndSuffix",
       "$alternateYear$numberAndSuffix",
+      "$year/$trimmedNumberAndSuffix",
+      "$alternateYear/$trimmedNumberAndSuffix",
     ).distinct()
+  }
+
+  private fun trimLeadingZeroesFromPncNumber(numberAndSuffix: String): String {
+    val number = numberAndSuffix.takeWhile(Char::isDigit)
+    val suffix = numberAndSuffix.drop(number.length)
+    return number.trimStart('0').ifEmpty { "0" } + suffix
   }
 
   private fun centuryPrefix(twoDigitYear: String): String = if (twoDigitYear.toInt() >= 50) "19" else "20"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.repository
 
+import mu.KotlinLogging
 import org.springframework.stereotype.Repository
 import software.amazon.awssdk.services.athena.model.Datum
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaQueryRunner
@@ -13,6 +14,8 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.m
 import java.time.LocalDate
 import kotlin.String
 
+private val log = KotlinLogging.logger {}
+
 @Repository
 class AthenaPersonRepository(
   private val runner: AthenaQueryRunner,
@@ -21,14 +24,29 @@ class AthenaPersonRepository(
 
   override fun searchPeople(personsQueryCriteria: PeopleQueryCriteria, nextToken: String?): PagedPeople {
     val built = buildPersonSearchSql(personsQueryCriteria)
+    val distinctOrderIds = mutableSetOf<String>()
 
     val result = runner.fetchPaged(
       sql = built.sql,
       database = properties.athena.defaultDatabase,
       cursor = nextToken,
       pageSize = properties.athena.rowLimit,
-      mapper = ::mapRow,
+      mapper = { cols ->
+        cols.getOrNull(COL_ORDER_ID)
+          ?.varCharValue()
+          ?.trim()
+          ?.takeIf(String::isNotEmpty)
+          ?.let(distinctOrderIds::add)
+
+        mapRow(cols)
+      },
       params = built.params,
+    )
+
+    log.info(
+      "Athena person search returned {} people with {} distinct orderIds",
+      result.items.size,
+      distinctOrderIds.size,
     )
 
     return PagedPeople(
@@ -70,7 +88,8 @@ class AthenaPersonRepository(
       c.date_of_birth AS u_dob,
       c.postcode AS zip,
       c.city_or_town AS city,
-      c.house_number_and_street_name AS street
+      c.house_number_and_street_name AS street,
+      c.order_id AS order_id
     FROM ${properties.athena.mdssDatabase}.caseload c
     ${builder.where}
     LIMIT ${properties.athena.rowLimit}
@@ -187,7 +206,7 @@ class AthenaPersonRepository(
       c.postcode AS zip,
       c.city_or_town AS city,
       c.house_number_and_street_name AS street,
-      c.unique_device_wearer_id AS u_id_device_wearer
+      c.order_id AS order_id
     FROM ${properties.athena.mdssDatabase}.caseload c
     WHERE c.mdss_person_id = CAST(? AS BIGINT)
     LIMIT 1
@@ -276,6 +295,7 @@ class AthenaPersonRepository(
       zip = v(COL_ZIP),
       city = v(COL_CITY),
       street = v(COL_STREET),
+      orderId = v(COL_ORDER_ID),
     )
   }
 
@@ -327,6 +347,7 @@ class AthenaPersonRepository(
     private const val COL_ZIP = 10
     private const val COL_CITY = 11
     private const val COL_STREET = 12
+    private const val COL_ORDER_ID = 13
     private const val COL_RAW_GROUPED_DATE = 0
     private const val COL_RAW_UNIQUE_DEVICE_WEARER_ID = 1
     private const val COL_RAW_FIRST_NAME = 2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,13 @@ spring:
         provider:
           hmpps-auth:
             token-uri: ${hmpps-auth.url}/oauth/token
+        registration:
+          probation-search-api:
+            provider: hmpps-auth
+            client-id: ${probation-search-api.client.id}
+            client-secret: ${probation-search-api.client.secret}
+            authorization-grant-type: client_credentials
+            scope: read
   http:
     codecs:
       max-in-memory-size: 10MB
@@ -79,3 +86,7 @@ springdoc:
 service:
   base-url: ${SERVICE_BASE_URL}
   ui-base-url: ${UI_SERVICE_BASE_URL}
+
+apis:
+  probation-search-api:
+    url: ${PROBATION_SEARCH_API_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,10 @@ service:
   base-url: ${SERVICE_BASE_URL}
   ui-base-url: ${UI_SERVICE_BASE_URL}
 
+probation:
+  search:
+    enabled: ${PROBATION_SEARCH_ENABLED:false}
+
 apis:
   probation-search-api:
     url: ${PROBATION_SEARCH_API_URL}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/client/probationsearch/ProbationSearchApiClientTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+
+class ProbationSearchApiClientTest {
+
+  private val probationSearchApi = WireMockServer(wireMockConfig().dynamicPort()).also { it.start() }
+  private val client = ProbationSearchApiClient(
+    WebClient.builder()
+      .baseUrl(probationSearchApi.baseUrl())
+      .build(),
+  )
+
+  @AfterEach
+  fun stopWireMock() {
+    probationSearchApi.stop()
+  }
+
+  @Test
+  fun `searchByCrn should post CRN to search endpoint and return other IDs`() {
+    probationSearchApi.stubFor(
+      post(urlEqualTo("/search"))
+        .withRequestBody(equalToJson("""{"crn":"X00001"}"""))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              [
+                {
+                  "offenderId": 123,
+                  "firstName": "Stephen",
+                  "surname": "McAllister",
+                  "dateOfBirth": "1980-01-02",
+                  "otherIds": {
+                    "crn": "X00001",
+                    "nomsNumber": "G5555TT"
+                  },
+                  "contactDetails": {
+                    "phoneNumbers": [
+                      {
+                        "number": "01234567890",
+                        "type": "TELEPHONE"
+                      }
+                    ]
+                  },
+                  "offenderManagers": [
+                    {
+                      "staff": {
+                        "code": "AN001A",
+                        "forenames": "Sheila Linda",
+                        "surname": "Hancock",
+                        "unallocated": false
+                      }
+                    }
+                  ],
+                  "probationStatus": {
+                    "status": "CURRENT",
+                    "inBreach": false
+                  },
+                  "age": 45
+                }
+              ]
+              """.trimIndent(),
+            ),
+        ),
+    )
+
+    val response = client.searchByCrn("X00001")
+
+    probationSearchApi.verify(
+      postRequestedFor(urlEqualTo("/search"))
+        .withRequestBody(equalToJson("""{"crn":"X00001"}""")),
+    )
+    assertThat(response).containsExactly(
+      OtherIds(crn = "X00001", nomsNumber = "G5555TT"),
+    )
+  }
+
+  @Test
+  fun `searchByCrn should wrap API errors`() {
+    probationSearchApi.stubFor(
+      post(urlEqualTo("/search"))
+        .willReturn(aResponse().withStatus(500)),
+    )
+
+    assertThatThrownBy { client.searchByCrn("X00001") }
+      .isInstanceOf(ProbationSearchApiException::class.java)
+      .hasMessage("Error searching Probation Search API by CRN X00001")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/IntegrationTestBase.kt
@@ -53,6 +53,11 @@ abstract class IntegrationTestBase {
     hmppsAuth.stubHealthPing(status)
   }
 
+  protected fun stubProbationSearchByCrn(crn: String, pncNumber: String? = null, nomsNumber: String? = null) {
+    hmppsAuth.stubGrantToken()
+    hmppsAuth.stubProbationSearchByCrn(crn, pncNumber, nomsNumber)
+  }
+
   protected fun stubQueryExecution(
     queryExecutionId: String,
     retryCount: Int,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/person/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/person/PersonSearchTest.kt
@@ -78,6 +78,7 @@ class PersonSearchTest : IntegrationTestBase() {
 
   @Test
   fun `Exists endpoint returns the correct URL`() {
+    stubProbationSearchByCrn("X123456", pncNumber = "2000/123456A", nomsNumber = "A1234BC")
     stubQueryExecution(
       "123",
       1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/person/PersonSearchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/person/PersonSearchTest.kt
@@ -45,6 +45,7 @@ class PersonSearchTest : IntegrationTestBase() {
     assertThat(person.zip).isEqualTo("SW1A 1AA")
     assertThat(person.city).isEqualTo("London")
     assertThat(person.street).isEqualTo("1 Test Street")
+    assertThat(person.orderId).isEqualTo("ORDER123")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.integra
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
@@ -68,6 +69,30 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
           .withBody(if (status == 200) """{"status":"UP"}""" else """{"status":"DOWN"}""")
           .withStatus(status),
       ),
+    )
+  }
+
+  fun stubProbationSearchByCrn(crn: String, pncNumber: String? = null, nomsNumber: String? = null) {
+    stubFor(
+      post(urlEqualTo("/search"))
+        .withRequestBody(equalToJson("""{"crn":"$crn"}"""))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              [
+                {
+                  "otherIds": {
+                    "crn": "$crn",
+                    "pncNumber": ${pncNumber?.let { "\"$it\"" } ?: "null"},
+                    "nomsNumber": ${nomsNumber?.let { "\"$it\"" } ?: "null"}
+                  }
+                }
+              ]
+              """.trimIndent(),
+            ),
+        ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.times
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.http.HttpStatus

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
@@ -105,6 +105,65 @@ class PersonControllerTest {
   }
 
   @Test
+  fun `searchPeople should enrich missing ids when requested`() {
+    val crn = "X123456"
+    val controller = PersonController(
+      personService = personService,
+      devPersonProvider = devPersonProvider,
+      currentUserService = currentUserService,
+      serviceProperties = serviceProperties,
+      probationSearchApiClient = probationSearchApiClient,
+      devStubEnabled = false,
+      probationSearchEnabled = true,
+    )
+    val pagedPeople = PagedPeople(listOf(Person(personId = "123456")), null)
+
+    whenever(probationSearchApiClient.searchByCrn(crn)).thenReturn(
+      listOf(OtherIds(crn = crn, pncNumber = "2012/0052494Q", nomsNumber = "G5555TT")),
+    )
+    whenever(
+      personService.searchPeople(
+        personsQueryCriteria = PeopleQueryCriteria(
+          deliusId = crn,
+          pncId = "EXISTING-PNC",
+          nomisId = "G5555TT",
+        ),
+      ),
+    ).thenReturn(pagedPeople)
+
+    val result = controller.searchPeople(
+      peopleQueryCriteria = PeopleQueryCriteria(
+        deliusId = crn,
+        pncId = "EXISTING-PNC",
+        enrichIds = true,
+      ),
+      nextToken = "next-token",
+    )
+
+    assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    assertThat(result.body).isEqualTo(PersonResponse(pagedPeople.persons, pagedPeople.nextToken))
+    verify(probationSearchApiClient, times(1)).searchByCrn(crn)
+  }
+
+  @Test
+  fun `searchPeople should not enrich ids when not requested`() {
+    val criteria = PeopleQueryCriteria(deliusId = "X123456", enrichIds = false)
+    val pagedPeople = PagedPeople(emptyList(), null)
+
+    whenever(
+      personService.searchPeople(
+        personsQueryCriteria = criteria,
+        nextToken = null,
+      ),
+    ).thenReturn(pagedPeople)
+
+    val result = controller.searchPeople(criteria, null)
+
+    assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    verifyNoInteractions(probationSearchApiClient)
+  }
+
+  @Test
   fun `exists endpoint should return 200 and person when they exist`() {
     val crn = "X123456"
     val mockPeople = PagedPeople(listOf(Person(personId = "123456")), null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.times
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.ObjectProvider
@@ -50,6 +51,7 @@ class PersonControllerTest {
       serviceProperties = serviceProperties,
       probationSearchApiClient = probationSearchApiClient,
       devStubEnabled = false,
+      probationSearchEnabled = false,
     )
   }
 
@@ -107,6 +109,34 @@ class PersonControllerTest {
     val crn = "X123456"
     val mockPeople = PagedPeople(listOf(Person(personId = "123456")), null)
 
+    whenever(
+      personService.searchPeople(
+        personsQueryCriteria = PeopleQueryCriteria(deliusId = crn),
+      ),
+    ).thenReturn(mockPeople)
+
+    val result = controller.existsInEMDI(crn)
+
+    assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    assertThat(result.body).isNotNull()
+    assertThat(result.body!!.uri.toString()).contains(crn)
+    verifyNoInteractions(probationSearchApiClient)
+  }
+
+  @Test
+  fun `exists endpoint should use probation search ids when enabled`() {
+    val crn = "X123456"
+    val mockPeople = PagedPeople(listOf(Person(personId = "123456")), null)
+    val controller = PersonController(
+      personService = personService,
+      devPersonProvider = devPersonProvider,
+      currentUserService = currentUserService,
+      serviceProperties = serviceProperties,
+      probationSearchApiClient = probationSearchApiClient,
+      devStubEnabled = false,
+      probationSearchEnabled = true,
+    )
+
     whenever(probationSearchApiClient.searchByCrn(crn)).thenReturn(
       listOf(OtherIds(crn = crn, pncNumber = "2012/0052494Q", nomsNumber = "G5555TT")),
     )
@@ -134,9 +164,6 @@ class PersonControllerTest {
     val crn = "X123456"
     val mockPeople = PagedPeople(emptyList(), null)
 
-    whenever(probationSearchApiClient.searchByCrn(crn)).thenReturn(
-      listOf(OtherIds(crn = crn)),
-    )
     whenever(
       personService.searchPeople(
         personsQueryCriteria = PeopleQueryCriteria(deliusId = crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/api/PersonControllerTest.kt
@@ -11,6 +11,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch.OtherIds
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.client.probationsearch.ProbationSearchApiClient
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.service.CurrentUserService
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.config.ServiceProperties
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.person.model.PagedPeople
@@ -34,6 +36,9 @@ class PersonControllerTest {
   @Mock
   private lateinit var currentUserService: CurrentUserService
 
+  @Mock
+  private lateinit var probationSearchApiClient: ProbationSearchApiClient
+
   private lateinit var controller: PersonController
 
   @BeforeEach
@@ -43,6 +48,7 @@ class PersonControllerTest {
       devPersonProvider = devPersonProvider,
       currentUserService = currentUserService,
       serviceProperties = serviceProperties,
+      probationSearchApiClient = probationSearchApiClient,
       devStubEnabled = false,
     )
   }
@@ -101,9 +107,16 @@ class PersonControllerTest {
     val crn = "X123456"
     val mockPeople = PagedPeople(listOf(Person(personId = "123456")), null)
 
+    whenever(probationSearchApiClient.searchByCrn(crn)).thenReturn(
+      listOf(OtherIds(crn = crn, pncNumber = "2012/0052494Q", nomsNumber = "G5555TT")),
+    )
     whenever(
       personService.searchPeople(
-        personsQueryCriteria = PeopleQueryCriteria(deliusId = crn),
+        personsQueryCriteria = PeopleQueryCriteria(
+          deliusId = crn,
+          pncId = "2012/0052494Q",
+          nomisId = "G5555TT",
+        ),
       ),
     ).thenReturn(mockPeople)
 
@@ -112,6 +125,7 @@ class PersonControllerTest {
     assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
     assertThat(result.body).isNotNull()
     assertThat(result.body!!.uri.toString()).contains(crn)
+    verify(probationSearchApiClient, times(1)).searchByCrn(crn)
   }
 
   @Test
@@ -120,6 +134,9 @@ class PersonControllerTest {
     val crn = "X123456"
     val mockPeople = PagedPeople(emptyList(), null)
 
+    whenever(probationSearchApiClient.searchByCrn(crn)).thenReturn(
+      listOf(OtherIds(crn = crn)),
+    )
     whenever(
       personService.searchPeople(
         personsQueryCriteria = PeopleQueryCriteria(deliusId = crn),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepositoryTest.kt
@@ -80,6 +80,7 @@ class AthenaPersonRepositoryTest {
       datum("LON 1243"), // 9: zip
       datum("City"), // 10: city
       datum("Street"), // 11: street
+      datum("ORDER123"), // 12: order_id
     )
 
     every { runner.run<Person>(any(), any(), any(), any(), any()) } answers {
@@ -99,6 +100,7 @@ class AthenaPersonRepositoryTest {
     assertThat(person.horId).isEqualTo("C6263919")
     assertThat(person.ceprId).isEqualTo("0987654321")
     assertThat(person.prisonId).isEqualTo("X69847")
+    assertThat(person.orderId).isEqualTo("ORDER123")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepositoryTest.kt
@@ -170,6 +170,82 @@ class AthenaPersonRepositoryTest {
   }
 
   @Test
+  fun `search should OR populated person identifiers`() {
+    val sqlSlot = slot<String>()
+    val paramsSlot = slot<List<String>>()
+
+    every {
+      runner.fetchPaged<Person>(
+        sql = capture(sqlSlot),
+        database = eq(properties.athena.defaultDatabase),
+        cursor = isNull(),
+        params = capture(paramsSlot),
+        pageSize = eq(properties.athena.rowLimit),
+        mapper = any(),
+      )
+    } returns PaginatedResult(emptyList(), null)
+
+    repository.searchPeople(
+      PeopleQueryCriteria(
+        nomisId = "A1234BC",
+        pncId = "2016/0305863C",
+        deliusId = "X123456",
+      ),
+      nextToken = null,
+    )
+
+    assertThat(sqlSlot.captured)
+      .contains(
+        "AND (c.nomis_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.delius_id = CAST(? AS VARCHAR))",
+      )
+
+    assertThat(paramsSlot.captured).startsWith(
+      "A1234BC",
+      "2016/0305863C",
+      "20160305863C",
+      "16/0305863C",
+      "160305863C",
+      "X123456",
+    )
+  }
+
+  @Test
+  fun `search should include four variations for two digit PNC years`() {
+    val sqlSlot = slot<String>()
+    val paramsSlot = slot<List<String>>()
+
+    every {
+      runner.fetchPaged<Person>(
+        sql = capture(sqlSlot),
+        database = eq(properties.athena.defaultDatabase),
+        cursor = isNull(),
+        params = capture(paramsSlot),
+        pageSize = eq(properties.athena.rowLimit),
+        mapper = any(),
+      )
+    } returns PaginatedResult(emptyList(), null)
+
+    repository.searchPeople(
+      PeopleQueryCriteria(
+        pncId = "95/0202300L",
+      ),
+      nextToken = null,
+    )
+
+    assertThat(sqlSlot.captured)
+      .contains(
+        "AND (c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR))",
+      )
+
+    assertThat(paramsSlot.captured).startsWith(
+      "95/0202300L",
+      "950202300L",
+      "1995/0202300L",
+      "19950202300L",
+    )
+  }
+
+  @Test
   fun `findRawCaseloadByDeliusId should query caseload table and map raw rows`() {
     val sqlSlot = slot<String>()
     val paramsSlot = slot<List<String>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/person/repository/AthenaPersonRepositoryTest.kt
@@ -198,7 +198,7 @@ class AthenaPersonRepositoryTest {
 
     assertThat(sqlSlot.captured)
       .contains(
-        "AND (c.nomis_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.delius_id = CAST(? AS VARCHAR))",
+        "AND (c.nomis_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.delius_id = CAST(? AS VARCHAR))",
       )
 
     assertThat(paramsSlot.captured).startsWith(
@@ -207,6 +207,8 @@ class AthenaPersonRepositoryTest {
       "20160305863C",
       "16/0305863C",
       "160305863C",
+      "2016/305863C",
+      "16/305863C",
       "X123456",
     )
   }
@@ -236,7 +238,7 @@ class AthenaPersonRepositoryTest {
 
     assertThat(sqlSlot.captured)
       .contains(
-        "AND (c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR))",
+        "AND (c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR) OR c.pnc_id = CAST(? AS VARCHAR))",
       )
 
     assertThat(paramsSlot.captured).startsWith(
@@ -244,6 +246,40 @@ class AthenaPersonRepositoryTest {
       "950202300L",
       "1995/0202300L",
       "19950202300L",
+      "95/202300L",
+      "1995/202300L",
+    )
+  }
+
+  @Test
+  fun `search should include leading zero trimmed PNC variations for four digit years`() {
+    val paramsSlot = slot<List<String>>()
+
+    every {
+      runner.fetchPaged<Person>(
+        sql = any(),
+        database = eq(properties.athena.defaultDatabase),
+        cursor = isNull(),
+        params = capture(paramsSlot),
+        pageSize = eq(properties.athena.rowLimit),
+        mapper = any(),
+      )
+    } returns PaginatedResult(emptyList(), null)
+
+    repository.searchPeople(
+      PeopleQueryCriteria(
+        pncId = "2018/0063295X",
+      ),
+      nextToken = null,
+    )
+
+    assertThat(paramsSlot.captured).startsWith(
+      "2018/0063295X",
+      "20180063295X",
+      "18/0063295X",
+      "180063295X",
+      "2018/63295X",
+      "18/63295X",
     )
   }
 

--- a/src/test/resources/__files/athenaResponses/people.search.success.json
+++ b/src/test/resources/__files/athenaResponses/people.search.success.json
@@ -175,7 +175,8 @@
           { "VarCharValue": "u_dob" },
           { "VarCharValue": "zip" },
           { "VarCharValue": "city" },
-          { "VarCharValue": "street" }
+          { "VarCharValue": "street" },
+          { "VarCharValue": "order_id" }
         ]
       },
       {
@@ -192,7 +193,8 @@
           { "VarCharValue": "1980-01-15" },
           { "VarCharValue": "SW1A 1AA" },
           { "VarCharValue": "London" },
-          { "VarCharValue": "1 Test Street" }
+          { "VarCharValue": "1 Test Street" },
+          {"VarCharValue": "ORDER123"}
         ]
       }
     ]

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,6 +8,11 @@ management.endpoint:
 hmpps-auth:
   url: "http://localhost:8090/auth"
 
+probation-search-api:
+  client:
+    id: probation-search-api-client
+    secret: client-secret
+
 aws:
   region: eu-west-2
   endpoint-url: http://localhost:8091
@@ -24,3 +29,7 @@ aws:
 service:
   base-url: http://localhost:8081
   ui-base-url: http://localhost:8081
+
+apis:
+  probation-search-api:
+    url: http://localhost:8090


### PR DESCRIPTION
Sorry - this one is pretty big. 

Basically we need to do some finagling with the IDs in order to get data back from Athena. The endpoint takes in a CRN and then goes off and gets the nomisId and PNCid from delius via [probation search api ](https://github.com/ministryofjustice/probation-offender-search) 

Then with those ids we query the Athena data using an OR search to get results back. This is because the Athena data can have ANY of those ids and almost certainly won't have all of them. Additionally sometimes the PNC id is stored without a / and with only 2 digit year so there is a function that passed in the 4 variants of that when a PNC id is present. 

And finally here is a sequence diagram that explains the whole thing... 

## EMDI CRN Lookup Flow

```mermaid
sequenceDiagram
    autonumber

    participant MPOP as MPOP API
    participant EMDI as EMDI API
    participant OffenderSearch as Offender Search API
    participant Delius as Delius DB
    participant EMDIDataStore as EMDI Data Store

    MPOP->>EMDI: Step 0 - Request

    EMDI->>OffenderSearch: Step 1 - Lookup using CRN
    OffenderSearch->>Delius: Search NOMIS / PNC / Order ID
    Delius-->>OffenderSearch: Matching identifiers
    OffenderSearch-->>EMDI: NOMIS / PNC / Order ID

    EMDI->>EMDIDataStore: Step 2 - Check EM data exists (incl. fuzzy matching / formatting)
    EMDIDataStore-->>EMDI: Match result

    EMDI-->>MPOP:  Return exists in EMDI
```