### PR TITLE
Added service status endpoint

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-data-insights-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-data-insights-api/values.yaml
@@ -21,6 +21,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_PORT: "5432"   # port is not secret, you can keep this here
     ATHENA_TIMEOUT_MS: "120000"
+    SERVICE_STATUS_CACHE_TIMEOUT: "5m"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/hmpps-electronic-monitoring-data-insights-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-data-insights-api/values.yaml
@@ -21,7 +21,8 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     DB_PORT: "5432"   # port is not secret, you can keep this here
     ATHENA_TIMEOUT_MS: "120000"
-    SERVICE_STATUS_CACHE_TIMEOUT: "5m"
+    SERVICE_STATUS_CACHE_TIMEOUT: "15m"
+    SERVICE_STATUS_DATA_OUT_OF_SYNC_THRESHOLD_MINUTES: "15"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/api/ServiceStatusController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/api/ServiceStatusController.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.HAS_VIEW_ROLE
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusResponse
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service.ServiceStatusService
+
+@RestController
+@PreAuthorize(HAS_VIEW_ROLE)
+@RequestMapping("/status")
+@Tag(name = "Service Status", description = "Endpoint to retrieve current service statuses")
+class ServiceStatusController(
+  private val serviceStatusService: ServiceStatusService,
+) {
+  @Operation(summary = "Get service status", description = "Returns active statuses for the service.")
+  @GetMapping
+  fun getStatus(): ServiceStatusResponse = serviceStatusService.getStatus()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/model/ServiceStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/model/ServiceStatus.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model
 
+import java.time.Instant
+
 data class ServiceStatusResponse(
   val statuses: List<ServiceStatus>,
 )
@@ -7,10 +9,11 @@ data class ServiceStatusResponse(
 data class ServiceStatus(
   val code: ServiceStatusCode,
   val description: String,
+  val latestPosition: Instant? = null,
 )
 
 enum class ServiceStatusCode(
   val description: String,
 ) {
-  RESTORE_IN_PROGRESS("Restore is in progress"),
+  DATA_OUT_OF_SYNC("Data out of sync"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/model/ServiceStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/model/ServiceStatus.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model
+
+data class ServiceStatusResponse(
+  val statuses: List<ServiceStatus>,
+)
+
+data class ServiceStatus(
+  val code: ServiceStatusCode,
+  val description: String,
+)
+
+enum class ServiceStatusCode(
+  val description: String,
+) {
+  RESTORE_IN_PROGRESS("Restore is in progress"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepository.kt
@@ -4,28 +4,41 @@ import org.springframework.stereotype.Repository
 import software.amazon.awssdk.services.athena.model.Datum
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaQueryRunner
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AwsProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.util.DateTimeConstants
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service.ServiceStatusProperties
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Repository
 class AthenaServiceStatusRepository(
   private val runner: AthenaQueryRunner,
   private val properties: AwsProperties,
+  private val serviceStatusProperties: ServiceStatusProperties,
 ) : ServiceStatusRepository {
 
-  override fun restoreInProgress(): Boolean = runner.run(
-    sql = RESTORE_IN_PROGRESS_SQL,
+  override fun getDataOutOfSyncLatestPosition(): Instant? = runner.run(
+    sql = buildSql(),
     database = properties.athena.mdssDatabase,
     skipHeaderRow = true,
-    mapper = ::mapCount,
-  ).singleOrNull() == 0L
+    mapper = ::mapLatestPosition,
+  ).singleOrNull()
 
-  private fun mapCount(cols: List<Datum>): Long = cols.firstOrNull()?.varCharValue()?.toLongOrNull()
-    ?: throw IllegalStateException("Restore status count query returned an invalid result")
-
-  companion object {
-    private val RESTORE_IN_PROGRESS_SQL = """
-      SELECT count(*)
+  private fun buildSql(): String =
+    """
+      SELECT max(position_gps_date) AS latest_position
       FROM position
-      WHERE position_gps_date >= date_trunc('day', current_timestamp)
+      HAVING max(position_gps_date) < date_add('minute', -${serviceStatusProperties.dataOutOfSyncThresholdMinutes}, current_timestamp)
     """.trimIndent()
+
+  private fun mapLatestPosition(cols: List<Datum>): Instant {
+    val latestPosition = cols.firstOrNull()?.varCharValue()
+      ?: throw IllegalStateException("Data out of sync status query returned an invalid latest position")
+
+    return try {
+      LocalDateTime.parse(latestPosition, DateTimeConstants.ATHENA_TIMESTAMP).toInstant(ZoneOffset.UTC)
+    } catch (e: Exception) {
+      throw IllegalStateException("Data out of sync status query returned an invalid latest position", e)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepository.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository
+
+import org.springframework.stereotype.Repository
+import software.amazon.awssdk.services.athena.model.Datum
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaQueryRunner
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AwsProperties
+
+@Repository
+class AthenaServiceStatusRepository(
+  private val runner: AthenaQueryRunner,
+  private val properties: AwsProperties,
+) : ServiceStatusRepository {
+
+  override fun restoreInProgress(): Boolean = runner.run(
+    sql = RESTORE_IN_PROGRESS_SQL,
+    database = properties.athena.mdssDatabase,
+    skipHeaderRow = true,
+    mapper = ::mapCount,
+  ).singleOrNull() == 0L
+
+  private fun mapCount(cols: List<Datum>): Long = cols.firstOrNull()?.varCharValue()?.toLongOrNull()
+    ?: throw IllegalStateException("Restore status count query returned an invalid result")
+
+  companion object {
+    private val RESTORE_IN_PROGRESS_SQL = """
+      SELECT count(*)
+      FROM position
+      WHERE position_gps_date >= date_trunc('day', current_timestamp)
+    """.trimIndent()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepository.kt
@@ -31,9 +31,8 @@ class AthenaServiceStatusRepository(
       HAVING max(position_gps_date) < date_add('minute', -${serviceStatusProperties.dataOutOfSyncThresholdMinutes}, current_timestamp)
     """.trimIndent()
 
-  private fun mapLatestPosition(cols: List<Datum>): Instant {
-    val latestPosition = cols.firstOrNull()?.varCharValue()
-      ?: throw IllegalStateException("Data out of sync status query returned an invalid latest position")
+  private fun mapLatestPosition(cols: List<Datum>): Instant? {
+    val latestPosition = cols.firstOrNull()?.varCharValue() ?: return null
 
     return try {
       LocalDateTime.parse(latestPosition, DateTimeConstants.ATHENA_TIMESTAMP).toInstant(ZoneOffset.UTC)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/ServiceStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/ServiceStatusRepository.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository
 
+import java.time.Instant
+
 interface ServiceStatusRepository {
-  fun restoreInProgress(): Boolean
+  fun getDataOutOfSyncLatestPosition(): Instant?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/ServiceStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/ServiceStatusRepository.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository
+
+interface ServiceStatusRepository {
+  fun restoreInProgress(): Boolean
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusCacheConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusCacheConfig.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service
+
+import mu.KotlinLogging
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+
+private val log = KotlinLogging.logger {}
+
+@Configuration
+@EnableCaching
+@EnableScheduling
+class ServiceStatusCacheConfig {
+
+  companion object {
+    const val SERVICE_STATUS_CACHE_NAME = "serviceStatus"
+  }
+
+  @Bean
+  fun cacheManager(): CacheManager = ConcurrentMapCacheManager(SERVICE_STATUS_CACHE_NAME)
+
+  @CacheEvict(value = [SERVICE_STATUS_CACHE_NAME], allEntries = true)
+  @Scheduled(fixedDelayString = "\${service.status.cache-timeout:5m}")
+  fun cacheEvictServiceStatus() {
+    log.info("Evicting cache: $SERVICE_STATUS_CACHE_NAME")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusProperties.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "service.status")
+data class ServiceStatusProperties(
+  val dataOutOfSyncThresholdMinutes: Int = 15,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusService.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service
+
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatus
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusCode
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusResponse
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository.ServiceStatusRepository
+
+@Service
+class ServiceStatusService(
+  private val repository: ServiceStatusRepository,
+) {
+  @Cacheable(ServiceStatusCacheConfig.SERVICE_STATUS_CACHE_NAME)
+  fun getStatus(): ServiceStatusResponse {
+    return ServiceStatusResponse(
+      statuses = if (repository.restoreInProgress()) {
+        listOf(ServiceStatus(ServiceStatusCode.RESTORE_IN_PROGRESS, ServiceStatusCode.RESTORE_IN_PROGRESS.description))
+      } else {
+        emptyList()
+      },
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusService.kt
@@ -12,11 +12,21 @@ class ServiceStatusService(
   private val repository: ServiceStatusRepository,
 ) {
   @Cacheable(ServiceStatusCacheConfig.SERVICE_STATUS_CACHE_NAME)
-  fun getStatus(): ServiceStatusResponse = ServiceStatusResponse(
-    statuses = if (repository.restoreInProgress()) {
-      listOf(ServiceStatus(ServiceStatusCode.RESTORE_IN_PROGRESS, ServiceStatusCode.RESTORE_IN_PROGRESS.description))
-    } else {
-      emptyList()
-    },
-  )
+  fun getStatus(): ServiceStatusResponse {
+    val latestPosition = repository.getDataOutOfSyncLatestPosition()
+
+    return ServiceStatusResponse(
+      statuses = if (latestPosition != null) {
+        listOf(
+          ServiceStatus(
+            code = ServiceStatusCode.DATA_OUT_OF_SYNC,
+            description = ServiceStatusCode.DATA_OUT_OF_SYNC.description,
+            latestPosition = latestPosition,
+          ),
+        )
+      } else {
+        emptyList()
+      },
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusService.kt
@@ -12,13 +12,11 @@ class ServiceStatusService(
   private val repository: ServiceStatusRepository,
 ) {
   @Cacheable(ServiceStatusCacheConfig.SERVICE_STATUS_CACHE_NAME)
-  fun getStatus(): ServiceStatusResponse {
-    return ServiceStatusResponse(
-      statuses = if (repository.restoreInProgress()) {
-        listOf(ServiceStatus(ServiceStatusCode.RESTORE_IN_PROGRESS, ServiceStatusCode.RESTORE_IN_PROGRESS.description))
-      } else {
-        emptyList()
-      },
-    )
-  }
+  fun getStatus(): ServiceStatusResponse = ServiceStatusResponse(
+    statuses = if (repository.restoreInProgress()) {
+      listOf(ServiceStatus(ServiceStatusCode.RESTORE_IN_PROGRESS, ServiceStatusCode.RESTORE_IN_PROGRESS.description))
+    } else {
+      emptyList()
+    },
+  )
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,7 @@ service:
   ui-base-url: ${UI_SERVICE_BASE_URL}
   status:
     cache-timeout: ${SERVICE_STATUS_CACHE_TIMEOUT:5m}
+    data-out-of-sync-threshold-minutes: ${SERVICE_STATUS_DATA_OUT_OF_SYNC_THRESHOLD_MINUTES:15}
 
 probation:
   search:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,8 @@ springdoc:
 service:
   base-url: ${SERVICE_BASE_URL}
   ui-base-url: ${UI_SERVICE_BASE_URL}
+  status:
+    cache-timeout: ${SERVICE_STATUS_CACHE_TIMEOUT:5m}
 
 probation:
   search:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/api/ServiceStatusControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/api/ServiceStatusControllerTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.services
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusCode
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusResponse
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service.ServiceStatusService
+import java.time.Instant
 
 class ServiceStatusControllerTest {
   private val serviceStatusService = mockk<ServiceStatusService>()
@@ -17,7 +18,13 @@ class ServiceStatusControllerTest {
   @Test
   fun `getStatus should return service statuses`() {
     val response = ServiceStatusResponse(
-      listOf(ServiceStatus(ServiceStatusCode.RESTORE_IN_PROGRESS, "Restore is in progress")),
+      listOf(
+        ServiceStatus(
+          code = ServiceStatusCode.DATA_OUT_OF_SYNC,
+          description = "Data out of sync",
+          latestPosition = Instant.parse("2026-06-26T10:15:30.123456Z"),
+        ),
+      ),
     )
     every { serviceStatusService.getStatus() } returns response
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/api/ServiceStatusControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/api/ServiceStatusControllerTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.api
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatus
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusCode
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusResponse
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service.ServiceStatusService
+
+class ServiceStatusControllerTest {
+  private val serviceStatusService = mockk<ServiceStatusService>()
+  private val controller = ServiceStatusController(serviceStatusService)
+
+  @Test
+  fun `getStatus should return service statuses`() {
+    val response = ServiceStatusResponse(
+      listOf(ServiceStatus(ServiceStatusCode.RESTORE_IN_PROGRESS, "Restore is in progress")),
+    )
+    every { serviceStatusService.getStatus() } returns response
+
+    val result = controller.getStatus()
+
+    assertThat(result).isEqualTo(response)
+    verify { serviceStatusService.getStatus() }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepositoryTest.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.athena.model.Datum
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaQueryRunner
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AwsProperties
+
+class AthenaServiceStatusRepositoryTest {
+  private val runner = mockk<AthenaQueryRunner>()
+  private val properties = AwsProperties(
+    region = Region.EU_WEST_2,
+    athena = AthenaProperties(
+      role = null,
+      mdssDatabase = "allied_mdss_test",
+      defaultDatabase = "allied_mdss_test",
+      outputLocation = "s3://bucket/output",
+      workgroup = "wg",
+    ),
+  )
+  private val repository = AthenaServiceStatusRepository(runner, properties)
+
+  @Test
+  fun `restoreInProgress should return true when position count is zero`() {
+    every { runner.run<Long>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Long
+      listOf(mapper(listOf(datum("0"))))
+    }
+
+    assertThat(repository.restoreInProgress()).isTrue()
+  }
+
+  @Test
+  fun `restoreInProgress should return false when position count is greater than zero`() {
+    every { runner.run<Long>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Long
+      listOf(mapper(listOf(datum("12"))))
+    }
+
+    assertThat(repository.restoreInProgress()).isFalse()
+  }
+
+  @Test
+  fun `restoreInProgress should run expected query against MDSS database`() {
+    val sqlSlot = slot<String>()
+    val databaseSlot = slot<String>()
+    every {
+      runner.run<Long>(
+        capture(sqlSlot),
+        capture(databaseSlot),
+        any(),
+        any(),
+        any(),
+      )
+    } returns listOf(1L)
+
+    repository.restoreInProgress()
+
+    assertThat(databaseSlot.captured).isEqualTo("allied_mdss_test")
+    assertThat(sqlSlot.captured).contains("SELECT count(*)")
+    assertThat(sqlSlot.captured).contains("FROM position")
+    assertThat(sqlSlot.captured).contains("position_gps_date >= date_trunc('day', current_timestamp)")
+  }
+
+  @Test
+  fun `restoreInProgress should throw when count cannot be mapped`() {
+    every { runner.run<Long>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Long
+      listOf(mapper(listOf(datum("not-a-number"))))
+    }
+
+    assertThrows<IllegalStateException> {
+      repository.restoreInProgress()
+    }
+  }
+
+  private fun datum(value: String?): Datum = Datum.builder().varCharValue(value).build()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepositoryTest.kt
@@ -34,8 +34,8 @@ class AthenaServiceStatusRepositoryTest {
 
   @Test
   fun `getDataOutOfSyncLatestPosition should return latest position when result row exists`() {
-    every { runner.run<Instant>(any(), any(), any(), any(), any()) } answers {
-      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant
+    every { runner.run<Instant?>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant?
       listOf(mapper(listOf(datum("2026-06-26 10:15:30.123456"))))
     }
 
@@ -43,8 +43,11 @@ class AthenaServiceStatusRepositoryTest {
   }
 
   @Test
-  fun `getDataOutOfSyncLatestPosition should return null when no result row exists`() {
-    every { runner.run<Instant>(any(), any(), any(), any(), any()) } returns emptyList()
+  fun `getDataOutOfSyncLatestPosition should return null when latest position is null`() {
+    every { runner.run<Instant?>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant?
+      listOf(mapper(listOf(datum(null))))
+    }
 
     assertThat(repository.getDataOutOfSyncLatestPosition()).isNull()
   }
@@ -54,7 +57,7 @@ class AthenaServiceStatusRepositoryTest {
     val sqlSlot = slot<String>()
     val databaseSlot = slot<String>()
     every {
-      runner.run<Instant>(
+      runner.run<Instant?>(
         capture(sqlSlot),
         capture(databaseSlot),
         any(),
@@ -73,8 +76,8 @@ class AthenaServiceStatusRepositoryTest {
 
   @Test
   fun `getDataOutOfSyncLatestPosition should throw when latest position cannot be mapped`() {
-    every { runner.run<Instant>(any(), any(), any(), any(), any()) } answers {
-      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant
+    every { runner.run<Instant?>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant?
       listOf(mapper(listOf(datum("not-a-number"))))
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/repository/AthenaServiceStatusRepositoryTest.kt
@@ -11,6 +11,8 @@ import software.amazon.awssdk.services.athena.model.Datum
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaProperties
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AthenaQueryRunner
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.athena.AwsProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service.ServiceStatusProperties
+import java.time.Instant
 
 class AthenaServiceStatusRepositoryTest {
   private val runner = mockk<AthenaQueryRunner>()
@@ -24,59 +26,60 @@ class AthenaServiceStatusRepositoryTest {
       workgroup = "wg",
     ),
   )
-  private val repository = AthenaServiceStatusRepository(runner, properties)
+  private val repository = AthenaServiceStatusRepository(
+    runner = runner,
+    properties = properties,
+    serviceStatusProperties = ServiceStatusProperties(dataOutOfSyncThresholdMinutes = 15),
+  )
 
   @Test
-  fun `restoreInProgress should return true when position count is zero`() {
-    every { runner.run<Long>(any(), any(), any(), any(), any()) } answers {
-      val mapper = it.invocation.args[3] as (List<Datum>) -> Long
-      listOf(mapper(listOf(datum("0"))))
+  fun `getDataOutOfSyncLatestPosition should return latest position when result row exists`() {
+    every { runner.run<Instant>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant
+      listOf(mapper(listOf(datum("2026-06-26 10:15:30.123456"))))
     }
 
-    assertThat(repository.restoreInProgress()).isTrue()
+    assertThat(repository.getDataOutOfSyncLatestPosition()).isEqualTo(Instant.parse("2026-06-26T10:15:30.123456Z"))
   }
 
   @Test
-  fun `restoreInProgress should return false when position count is greater than zero`() {
-    every { runner.run<Long>(any(), any(), any(), any(), any()) } answers {
-      val mapper = it.invocation.args[3] as (List<Datum>) -> Long
-      listOf(mapper(listOf(datum("12"))))
-    }
+  fun `getDataOutOfSyncLatestPosition should return null when no result row exists`() {
+    every { runner.run<Instant>(any(), any(), any(), any(), any()) } returns emptyList()
 
-    assertThat(repository.restoreInProgress()).isFalse()
+    assertThat(repository.getDataOutOfSyncLatestPosition()).isNull()
   }
 
   @Test
-  fun `restoreInProgress should run expected query against MDSS database`() {
+  fun `getDataOutOfSyncLatestPosition should run expected query against MDSS database`() {
     val sqlSlot = slot<String>()
     val databaseSlot = slot<String>()
     every {
-      runner.run<Long>(
+      runner.run<Instant>(
         capture(sqlSlot),
         capture(databaseSlot),
         any(),
         any(),
         any(),
       )
-    } returns listOf(1L)
+    } returns listOf(Instant.parse("2026-06-26T10:15:30Z"))
 
-    repository.restoreInProgress()
+    repository.getDataOutOfSyncLatestPosition()
 
     assertThat(databaseSlot.captured).isEqualTo("allied_mdss_test")
-    assertThat(sqlSlot.captured).contains("SELECT count(*)")
+    assertThat(sqlSlot.captured).contains("SELECT max(position_gps_date) AS latest_position")
     assertThat(sqlSlot.captured).contains("FROM position")
-    assertThat(sqlSlot.captured).contains("position_gps_date >= date_trunc('day', current_timestamp)")
+    assertThat(sqlSlot.captured).contains("HAVING max(position_gps_date) < date_add('minute', -15, current_timestamp)")
   }
 
   @Test
-  fun `restoreInProgress should throw when count cannot be mapped`() {
-    every { runner.run<Long>(any(), any(), any(), any(), any()) } answers {
-      val mapper = it.invocation.args[3] as (List<Datum>) -> Long
+  fun `getDataOutOfSyncLatestPosition should throw when latest position cannot be mapped`() {
+    every { runner.run<Instant>(any(), any(), any(), any(), any()) } answers {
+      val mapper = it.invocation.args[3] as (List<Datum>) -> Instant
       listOf(mapper(listOf(datum("not-a-number"))))
     }
 
     assertThrows<IllegalStateException> {
-      repository.restoreInProgress()
+      repository.getDataOutOfSyncLatestPosition()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusCacheConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusCacheConfigTest.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+
+class ServiceStatusCacheConfigTest {
+
+  @Test
+  fun `cacheManager should configure service status cache`() {
+    val cacheManager = ServiceStatusCacheConfig().cacheManager()
+
+    assertThat(cacheManager).isInstanceOf(ConcurrentMapCacheManager::class.java)
+    assertThat(cacheManager.cacheNames).containsExactly(ServiceStatusCacheConfig.SERVICE_STATUS_CACHE_NAME)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusServiceTest.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.annotation.Cacheable
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusCode
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository.ServiceStatusRepository
+
+class ServiceStatusServiceTest {
+  private val repository = mockk<ServiceStatusRepository>()
+  private val service = ServiceStatusService(
+    repository = repository,
+  )
+
+  @Test
+  fun `getStatus should return restore status when restore is in progress`() {
+    every { repository.restoreInProgress() } returns true
+
+    val response = service.getStatus()
+
+    assertThat(response.statuses).hasSize(1)
+    assertThat(response.statuses[0].code).isEqualTo(ServiceStatusCode.RESTORE_IN_PROGRESS)
+    assertThat(response.statuses[0].description).isEqualTo("Restore is in progress")
+  }
+
+  @Test
+  fun `getStatus should return no statuses when restore is not in progress`() {
+    every { repository.restoreInProgress() } returns false
+
+    val response = service.getStatus()
+
+    assertThat(response.statuses).isEmpty()
+  }
+
+  @Test
+  fun `getStatus should be cacheable`() {
+    val cacheable = ServiceStatusService::class.java
+      .getMethod("getStatus")
+      .getAnnotation(Cacheable::class.java)
+
+    assertThat(cacheable.value).containsExactly(ServiceStatusCacheConfig.SERVICE_STATUS_CACHE_NAME)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/servicestatus/service/ServiceStatusServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.cache.annotation.Cacheable
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.model.ServiceStatusCode
 import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.servicestatus.repository.ServiceStatusRepository
+import java.time.Instant
 
 class ServiceStatusServiceTest {
   private val repository = mockk<ServiceStatusRepository>()
@@ -15,19 +16,20 @@ class ServiceStatusServiceTest {
   )
 
   @Test
-  fun `getStatus should return restore status when restore is in progress`() {
-    every { repository.restoreInProgress() } returns true
+  fun `getStatus should return data out of sync status when data is out of sync`() {
+    every { repository.getDataOutOfSyncLatestPosition() } returns Instant.parse("2026-06-26T10:15:30.123456Z")
 
     val response = service.getStatus()
 
     assertThat(response.statuses).hasSize(1)
-    assertThat(response.statuses[0].code).isEqualTo(ServiceStatusCode.RESTORE_IN_PROGRESS)
-    assertThat(response.statuses[0].description).isEqualTo("Restore is in progress")
+    assertThat(response.statuses[0].code).isEqualTo(ServiceStatusCode.DATA_OUT_OF_SYNC)
+    assertThat(response.statuses[0].description).isEqualTo("Data out of sync")
+    assertThat(response.statuses[0].latestPosition).isEqualTo(Instant.parse("2026-06-26T10:15:30.123456Z"))
   }
 
   @Test
-  fun `getStatus should return no statuses when restore is not in progress`() {
-    every { repository.restoreInProgress() } returns false
+  fun `getStatus should return no statuses when data is not out of sync`() {
+    every { repository.getDataOutOfSyncLatestPosition() } returns null
 
     val response = service.getStatus()
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -31,6 +31,7 @@ service:
   ui-base-url: http://localhost:8081
   status:
     cache-timeout: 5m
+    data-out-of-sync-threshold-minutes: 15
 
 apis:
   probation-search-api:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -29,6 +29,8 @@ aws:
 service:
   base-url: http://localhost:8081
   ui-base-url: http://localhost:8081
+  status:
+    cache-timeout: 5m
 
 apis:
   probation-search-api:


### PR DESCRIPTION
Endpoint to return the status of the API. 

With this implementation it will return a message when the athena data is out of sync together with the most recent date that the data was in sync. If the most recent data is older than 15mins it is deemed to be out of sync - this is configurable. 

Since the method that checks the data is quite slow it will only check the data once every 15 mins - this is configurable. Otherwise it will return the cached status. 

```mermaid
sequenceDiagram
    participant Client
    participant Controller as ServiceStatusController
    participant Service as ServiceStatusService
    participant Cache as Spring Cache<br/>serviceStatus
    participant Repository as AthenaServiceStatusRepository
    participant Athena as Athena

    Client->>Controller: GET /status
    Controller->>Service: getStatus()

    Service->>Cache: Check cached getStatus() result

    alt Cached response exists
        Cache-->>Service: ServiceStatusResponse
        Service-->>Controller: ServiceStatusResponse
        Controller-->>Client: 200 OK
    else Cache miss
        Service->>Repository: getDataOutOfSyncLatestPosition()

        Repository->>Athena: Run latest position query
        Note over Repository,Athena: SELECT max(position_gps_date) AS latest_position<br/>FROM position<br/>HAVING max(position_gps_date) < date_add('minute', -threshold, current_timestamp)

        Athena-->>Repository: latest_position row

        alt latest_position is null
            Repository-->>Service: null
            Service->>Service: Build response with empty statuses
        else latest_position has value
            Repository-->>Service: Instant latestPosition
            Service->>Service: Build DATA_OUT_OF_SYNC status<br/>including latestPosition
        end

        Service->>Cache: Cache ServiceStatusResponse
        Service-->>Controller: ServiceStatusResponse
        Controller-->>Client: 200 OK
    end

    Note over Cache: Scheduled eviction clears cache<br/>after service.status.cache-timeout
```