### PR TITLE
Added endpoint to return exclusion-zones for a person

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/api/ExclusionZoneController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/api/ExclusionZoneController.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.common.HAS_VIEW_ROLE
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.model.CoordinateReferenceSystem
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.model.CoordinateReferenceSystemProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.model.ExclusionZone
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.model.Geometry
+
+@RestController
+@RequestMapping("/people/{personId}/exclusion-zones")
+@Tag(name = "Exclusion Zones", description = "Endpoint to retrieve exclusion zones for a person by personId")
+class ExclusionZoneController {
+
+  // TODO - hardcoded exclusion zones for dev person for now. This will get the exclusion zones from the database once we have the derived data in the database
+  companion object {
+    private const val DEV_PERSON_ID = "777777"
+
+    private val DEV_EXCLUSION_ZONES = listOf(
+      ExclusionZone(
+        name = "St James Park",
+        address = "St. James's Park in London SW1A 2BJ",
+        geometry = Geometry(
+          type = "Polygon",
+          crs = CoordinateReferenceSystem(
+            type = "name",
+            properties = CoordinateReferenceSystemProperties(name = "EPSG:4326"),
+          ),
+          coordinates = listOf(
+            listOf(
+              listOf(-0.132646597116215, 51.50525361293847),
+              listOf(-0.129900015084965, 51.50620856945221),
+              listOf(-0.127829349725468, 51.50148033725193),
+              listOf(-0.141090191095097, 51.50014458956852),
+              listOf(-0.140909976247892, 51.50224330385428),
+              listOf(-0.132646597116215, 51.50525361293847),
+            ),
+          ),
+        ),
+      ),
+    )
+  }
+
+  @Operation(
+    summary = "Get exclusion zones",
+    description = "Returns a list of exclusion zones for a personId.",
+  )
+  @GetMapping
+  @PreAuthorize(HAS_VIEW_ROLE)
+  fun getExclusionZones(@PathVariable personId: String): ResponseEntity<ExclusionZoneResponse> {
+    val exclusionZones = if (personId == DEV_PERSON_ID) {
+      DEV_EXCLUSION_ZONES
+    } else {
+      emptyList()
+    }
+
+    return ResponseEntity.ok(ExclusionZoneResponse(exclusionZones))
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/api/ExclusionZoneResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/api/ExclusionZoneResponse.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.api
+
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.model.ExclusionZone
+
+data class ExclusionZoneResponse(
+  val exclusionZones: List<ExclusionZone>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/model/ExclusionZone.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/model/ExclusionZone.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.model
+
+data class ExclusionZone(
+  val name: String,
+  val address: String,
+  val geometry: Geometry,
+)
+
+data class Geometry(
+  val type: String,
+  val crs: CoordinateReferenceSystem,
+  val coordinates: List<List<List<Double>>>,
+)
+
+data class CoordinateReferenceSystem(
+  val type: String,
+  val properties: CoordinateReferenceSystemProperties,
+)
+
+data class CoordinateReferenceSystemProperties(
+  val name: String,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/api/ExclusionZoneControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/exclusionzone/api/ExclusionZoneControllerTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExclusionZoneControllerTest {
+
+  private val exclusionZoneController = ExclusionZoneController()
+
+  @Test
+  fun `getExclusionZones should return hardcoded exclusion zone for dev person`() {
+    val result = exclusionZoneController.getExclusionZones("777777")
+
+    assertThat(result.statusCode.value()).isEqualTo(200)
+    assertThat(result.body?.exclusionZones).hasSize(1)
+
+    val exclusionZone = result.body?.exclusionZones?.first()
+    assertThat(exclusionZone?.name).isEqualTo("St James Park")
+    assertThat(exclusionZone?.address).isEqualTo("St. James's Park in London SW1A 2BJ")
+    assertThat(exclusionZone?.geometry?.type).isEqualTo("Polygon")
+    assertThat(exclusionZone?.geometry?.crs?.type).isEqualTo("name")
+    assertThat(exclusionZone?.geometry?.crs?.properties?.name).isEqualTo("EPSG:4326")
+    assertThat(exclusionZone?.geometry?.coordinates).hasSize(1)
+    assertThat(exclusionZone?.geometry?.coordinates?.first()).containsExactly(
+      listOf(-0.132646597116215, 51.50525361293847),
+      listOf(-0.129900015084965, 51.50620856945221),
+      listOf(-0.127829349725468, 51.50148033725193),
+      listOf(-0.141090191095097, 51.50014458956852),
+      listOf(-0.140909976247892, 51.50224330385428),
+      listOf(-0.132646597116215, 51.50525361293847),
+    )
+  }
+
+  @Test
+  fun `getExclusionZones should return empty list for other people`() {
+    val result = exclusionZoneController.getExclusionZones("123456")
+
+    assertThat(result.statusCode.value()).isEqualTo(200)
+    assertThat(result.body?.exclusionZones).isEmpty()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/exclusionzone/PersonExclusionZoneTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringdatainsightsapi/integration/exclusionzone/PersonExclusionZoneTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.integration.exclusionzone
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.exclusionzone.api.ExclusionZoneResponse
+import uk.gov.justice.digital.hmpps.electronicmonitoringdatainsightsapi.integration.IntegrationTestBase
+
+class PersonExclusionZoneTest : IntegrationTestBase() {
+
+  @Test
+  fun `Get person exclusion zones returns hardcoded exclusion zone`() {
+    val response = webTestClient.get()
+      .uri("/people/777777/exclusion-zones")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<ExclusionZoneResponse>()
+      .returnResult()
+      .responseBody!!
+
+    assertThat(response.exclusionZones).hasSize(1)
+    assertThat(response.exclusionZones[0].name).isEqualTo("St James Park")
+    assertThat(response.exclusionZones[0].address).isEqualTo("St. James's Park in London SW1A 2BJ")
+    assertThat(response.exclusionZones[0].geometry.type).isEqualTo("Polygon")
+    assertThat(response.exclusionZones[0].geometry.crs.type).isEqualTo("name")
+    assertThat(response.exclusionZones[0].geometry.crs.properties.name).isEqualTo("EPSG:4326")
+    assertThat(response.exclusionZones[0].geometry.coordinates).hasSize(1)
+    assertThat(response.exclusionZones[0].geometry.coordinates.first()).containsExactly(
+      listOf(-0.132646597116215, 51.50525361293847),
+      listOf(-0.129900015084965, 51.50620856945221),
+      listOf(-0.127829349725468, 51.50148033725193),
+      listOf(-0.141090191095097, 51.50014458956852),
+      listOf(-0.140909976247892, 51.50224330385428),
+      listOf(-0.132646597116215, 51.50525361293847),
+    )
+  }
+
+  @Test
+  fun `Get person exclusion zones returns geometry as an object`() {
+    webTestClient.get()
+      .uri("/people/777777/exclusion-zones")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.exclusionZones[0].geometry.type").isEqualTo("Polygon")
+      .jsonPath("$.exclusionZones[0].geometry.crs.properties.name").isEqualTo("EPSG:4326")
+      .jsonPath("$.exclusionZones[0].geometry.coordinates[0][0][0]").isEqualTo(-0.132646597116215)
+      .jsonPath("$.exclusionZones[0].geometry.coordinates[0][0][1]").isEqualTo(51.50525361293847)
+  }
+
+  @Test
+  fun `Get person exclusion zones returns empty array when no exclusion zones found`() {
+    webTestClient.get()
+      .uri("/people/123456/exclusion-zones")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.exclusionZones").isArray
+      .jsonPath("$.exclusionZones.length()").isEqualTo(0)
+  }
+}


### PR DESCRIPTION
This is a real endpoint that serves up hard coded exclusion geometry position data. The data is not available in our derived tables so is based on the data that is available so should still match this response when we do have the data. 

